### PR TITLE
Fix import error message in ghdl target

### DIFF
--- a/vhdeps/targets/ghdl.py
+++ b/vhdeps/targets/ghdl.py
@@ -20,9 +20,12 @@ import sys
 def run(l, f):
     try:
         from plumbum import local, ProcessExecutionError, FG
-        from plumbum.cmd import ghdl
     except ImportError:
         raise ImportError('The GHDL backend requires plumbum to be installed (pip3 install plumbum).')
+    try:
+        from plumbum.cmd import ghdl
+    except ImportError:
+        raise ImportError('The GHDL backend requires ghdl to be installed (https://github.com/ghdl/ghdl).')
 
     # Make sure all files in the compile order have the same version.
     versions = set()


### PR DESCRIPTION
It now suggests to install `ghdl` if `plumbum` is available.