### PR TITLE
Use edit action in GitHub release task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,9 @@ jobs:
     inputs:
       gitHubConnection: github
       repositoryName: abs-tudelft/vhdeps
+      action: edit
+      tag: $(Build.SourceBranchName)
       assets: $(System.DefaultWorkingDirectory)/dist/*.whl
       addChangeLog: true
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
     displayName: Publish to GitHub


### PR DESCRIPTION
The task seems to work, but generates the following error:
```
##[error]Failed to create the release. A release already exists for tag: 0.1.0
##[error]Error: Validation Failed
```

This is an attempt to fix that error.