### PR TITLE
Add pragmas to ignore use of pkg/entity/component

### DIFF
--- a/tests/complex/ignore-use/a.vhd
+++ b/tests/complex/ignore-use/a.vhd
@@ -1,0 +1,18 @@
+
+-- pragma vhdeps ignore package x
+library work;
+use work.x.all;
+
+entity a is
+end a;
+
+architecture struct of a is
+begin
+
+  -- pragma vhdeps ignore entity b
+  b_inst: entity work.b;
+
+  -- pragma vhdeps ignore component c
+  c_inst: c generic map (x => 1);
+
+end struct;

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -160,6 +160,11 @@ class TestDump(TestCase):
         self.assertTrue('ResolutionError: entity work.test_tc is defined in '
                         'multiple, ambiguous files:' in err)
 
+    def test_ignore_pragmas(self):
+        """Test ignore-use pragmas"""
+        code, _, err = run_vhdeps('dump', '-i', DIR + '/complex/ignore-use')
+        self.assertEqual(code, 0)
+
     def test_missing_package(self):
         """Test missing package detection/error"""
         code, _, err = run_vhdeps('dump', '-i', DIR + '/complex/vhlib/util/UtilMem64_pkg.vhd')

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -162,7 +162,7 @@ class TestDump(TestCase):
 
     def test_ignore_pragmas(self):
         """Test ignore-use pragmas"""
-        code, _, err = run_vhdeps('dump', '-i', DIR + '/complex/ignore-use')
+        code, _, _ = run_vhdeps('dump', '-i', DIR + '/complex/ignore-use')
         self.assertEqual(code, 0)
 
     def test_missing_package(self):

--- a/tests/test_ghdl.py
+++ b/tests/test_ghdl.py
@@ -22,8 +22,8 @@ def coverage_supported():
     """Returns whether all the dependencies for producing code coverage with
     GHDL are met."""
     try:
-        from plumbum.cmd import ghdl, gcov, lcov, genhtml #pylint: disable=W0611
-        import lcov_cobertura #pylint: disable=W0611
+        from plumbum.cmd import ghdl, gcov, lcov, genhtml #pylint: disable=W0611,C0415
+        import lcov_cobertura #pylint: disable=W0611,C0415
         return 'GCC back-end' in ghdl('--version')
     except ImportError:
         return False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,28 +38,28 @@ class TestMain(TestCase):
 
     def test_no_args_main(self):
         """Test `vhdeps` without arguments (exit code 1)"""
-        import vhdeps
+        import vhdeps #pylint: disable=C0415
         code, _, err = run_vhdeps_main(vhdeps)
         self.assertEqual(code, 1)
         self.assertTrue('Error: no target specified.' in err)
 
     def test_help_main(self):
         """Test `vhdeps` with the --help argument (exit code 0)"""
-        import vhdeps
+        import vhdeps #pylint: disable=C0415
         code, out, _ = run_vhdeps_main(vhdeps, '--help')
         self.assertEqual(code, 0)
         self.assertTrue('vhdeps <target> [entities...] [flags...] [--] [target-flags...]' in out)
 
     def test_no_args_module(self):
         """Test `vhdeps.__main__` without arguments (exit code 1)"""
-        import vhdeps.__main__ as mod
+        import vhdeps.__main__ as mod #pylint: disable=C0415
         code, _, err = run_vhdeps_main(mod)
         self.assertEqual(code, 1)
         self.assertTrue('Error: no target specified.' in err)
 
     def test_help_module(self):
         """Test `vhdeps.__main__` with the --help argument (exit code 0)"""
-        import vhdeps.__main__ as mod
+        import vhdeps.__main__ as mod #pylint: disable=C0415
         code, out, _ = run_vhdeps_main(mod, '--help')
         self.assertEqual(code, 0)
         self.assertTrue('vhdeps <target> [entities...] [flags...] [--] [target-flags...]' in out)


### PR DESCRIPTION
This is useful for when a VHDL file needs to use a vendor primitive library or something of the sort that is in scope implicitly, without vhdeps' knowledge.