### PR TITLE
Fix vsim signal coloring error

### DIFF
--- a/vhdeps/targets/vsim.py
+++ b/vhdeps/targets/vsim.py
@@ -205,8 +205,8 @@ proc add_signals_to_wave {
     foreach obj $vhd_list {
       # get leaf name
       set nam [lindex [split $obj /] end]
-      # change color
-      property wave $nam -color $color
+      # (try to) change color
+      catch { property wave $nam -color $color }
     }
   }
 


### PR DESCRIPTION
If the user removes signals from the waveform view and then calls `rerun`, the script would crash trying to color the now nonexistent signals. Adding a `catch` around it solves the problem.